### PR TITLE
fix: replace placeholder username with actual GitHub username in workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
   claude-review:
     # Only allow your-username to trigger on comments with "/claude-review"
     if: |
-      github.actor == 'your-username' && (
+      github.actor == 'amendez13' && (
         github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude-review'))
       )

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude:
     if: |
-      github.actor == 'your-username' && (
+      github.actor == 'amendez13' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
The Claude GitHub Actions workflows were being skipped because they contained a hardcoded placeholder 'your-username' instead of the actual GitHub username 'amendez13'. This caused the conditional checks to fail, preventing the workflows from running when triggered.

Changed:
- .github/workflows/claude.yml: Updated github.actor condition
- .github/workflows/claude-code-review.yml: Updated github.actor condition