### PR TITLE
feat: add email filters and CLI support

### DIFF
--- a/src/email/__init__.py
+++ b/src/email/__init__.py
@@ -1,6 +1,7 @@
 """Email fetching and processing module."""
 
 from src.email.client import EmailClient
+from src.email.filters import EmailFilter
 from src.email.models import Email, EmailAddress, MailFolder
 
-__all__ = ["EmailClient", "Email", "EmailAddress", "MailFolder"]
+__all__ = ["EmailClient", "EmailFilter", "Email", "EmailAddress", "MailFolder"]

--- a/src/email/filters.py
+++ b/src/email/filters.py
@@ -1,0 +1,67 @@
+"""OData filter builder for email queries."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+class EmailFilter:
+    """Build OData filter strings for Microsoft Graph email queries."""
+
+    def __init__(self) -> None:
+        self._conditions: list[str] = []
+
+    def from_address(self, email: str) -> "EmailFilter":
+        """Filter by sender email address."""
+        if not email or not email.strip():
+            raise ValueError("Sender address cannot be empty.")
+        self._conditions.append(f"from/emailAddress/address eq '{_escape_odata_string(email.strip())}'")
+        return self
+
+    def subject_contains(self, text: str) -> "EmailFilter":
+        """Filter by subject containing text."""
+        if not text or not text.strip():
+            raise ValueError("Subject filter text cannot be empty.")
+        self._conditions.append(f"contains(subject, '{_escape_odata_string(text.strip())}')")
+        return self
+
+    def received_after(self, dt: datetime) -> "EmailFilter":
+        """Filter emails received after date."""
+        self._conditions.append(f"receivedDateTime ge {_format_datetime(dt)}")
+        return self
+
+    def received_before(self, dt: datetime) -> "EmailFilter":
+        """Filter emails received before date."""
+        self._conditions.append(f"receivedDateTime le {_format_datetime(dt)}")
+        return self
+
+    def is_read(self, read: bool = True) -> "EmailFilter":
+        """Filter by read status."""
+        self._conditions.append(f"isRead eq {str(read).lower()}")
+        return self
+
+    def has_attachments(self, has: bool = True) -> "EmailFilter":
+        """Filter by attachment presence."""
+        self._conditions.append(f"hasAttachments eq {str(has).lower()}")
+        return self
+
+    def build(self) -> str:
+        """Build OData filter string."""
+        return " and ".join(self._conditions)
+
+
+def _escape_odata_string(value: str) -> str:
+    """Escape single quotes for OData string literals."""
+    return value.replace("'", "''")
+
+
+def _format_datetime(dt: datetime) -> str:
+    """Format datetime in ISO 8601 with UTC Z suffix."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    formatted = dt.isoformat()
+    if formatted.endswith("+00:00"):
+        formatted = formatted.replace("+00:00", "Z")
+    return formatted

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,43 @@
+"""Tests for the email filter builder."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.email.filters import EmailFilter
+
+
+def test_build_empty_returns_empty_string() -> None:
+    """build should return empty string when no conditions are set."""
+    assert EmailFilter().build() == ""
+
+
+def test_from_and_subject_escape_quotes() -> None:
+    """from_address and subject_contains should escape single quotes."""
+    email_filter = EmailFilter().from_address("o'malley@example.com").subject_contains("it's here")
+    assert email_filter.build() == ("from/emailAddress/address eq 'o''malley@example.com' and contains(subject, 'it''s here')")
+
+
+def test_received_date_filters_format_utc() -> None:
+    """received_after/received_before should format datetimes with Z suffix."""
+    dt = datetime(2024, 1, 1, 12, 0, tzinfo=timezone(timedelta(hours=-5)))
+    email_filter = EmailFilter().received_after(dt).received_before(dt)
+    assert email_filter.build() == ("receivedDateTime ge 2024-01-01T17:00:00Z and receivedDateTime le 2024-01-01T17:00:00Z")
+
+
+def test_read_and_attachment_filters() -> None:
+    """is_read and has_attachments should set boolean filters."""
+    email_filter = EmailFilter().is_read(False).has_attachments(True)
+    assert email_filter.build() == "isRead eq false and hasAttachments eq true"
+
+
+def test_from_address_empty_raises() -> None:
+    """from_address should reject empty input."""
+    with pytest.raises(ValueError, match="Sender address cannot be empty"):
+        EmailFilter().from_address("   ")
+
+
+def test_subject_empty_raises() -> None:
+    """subject_contains should reject empty input."""
+    with pytest.raises(ValueError, match="Subject filter text cannot be empty"):
+        EmailFilter().subject_contains("")


### PR DESCRIPTION
## Summary
- add EmailFilter OData builder and integrate with EmailClient
- add CLI fetch filters with validation (from/subject/date/read/attachments)
- add unit tests for filters and integration

## Testing
- source venv/bin/activate
- pytest --cov=src --cov-report=term-missing