### PR TITLE
fix: persist MSAL auth record

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For database setup and migrations, see [Database Guide](docs/DATABASE.md).
 - **Authentication fails or client_id missing**: Ensure `azure.client_id` is set in `config/config.yaml` or `AZURE_CLIENT_ID` is exported.
 - **Device code flow never completes**: Confirm the account used to sign in has granted consent to the app registration.
 - **Login output is noisy (HTTP polling spam)**: Set `logging.level` to `WARNING` in `config/config.yaml` or run with `LOGGING_LEVEL=WARNING`, then retry `login`.
-- **Token cache is stale**: Delete the file at `storage.token_file` and re-run `login`.
+- **Token cache/auth record is stale**: Delete `~/.outmylook/auth_record.json` (and optionally `storage.token_file`) and re-run `login`.
 - **SQLite database is locked**: Make sure no other process is using the DB; restart any running fetch/list/export commands.
 - **Attachments not downloading**: Confirm the `Mail.Read` scope is present and the email actually has attachments.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -34,11 +34,12 @@ python -m src.main login
 What happens:
 - The CLI prints a URL and a device code.
 - Open the URL in a browser and enter the code.
-- A token is cached locally for future use.
+- MSAL caches tokens and OutMyLook stores a non-secret auth record for reuse.
 
-Tokens are stored at the path configured in `storage.token_file` (default:
-`~/.outmylook/tokens.json`). The cache is used for subsequent commands and
-refreshed automatically before expiry.
+Authentication is reused via MSAL's persistent cache and a local auth record
+stored at `~/.outmylook/auth_record.json`. The `storage.token_file` JSON (default
+`~/.outmylook/tokens.json`) is informational for status/troubleshooting and not
+used for authentication.
 
 ### Status
 
@@ -63,7 +64,8 @@ If the token is close to expiring, the CLI warns that it will refresh on the nex
 python -m src.main logout
 ```
 
-Clears the cached token so the next command will require re-authentication.
+Clears the auth record and cached token metadata so the next command will
+require re-authentication.
 
 ## Fetching Email
 
@@ -237,7 +239,7 @@ Required values:
 Optional values:
 - `azure.tenant`: Use `common` for personal accounts, or your tenant ID.
 - `azure.scopes`: Graph API scopes (defaults are set in `config/config.example.yaml`).
-- `storage.token_file`: Token cache path.
+- `storage.token_file`: Informational token cache path (used for status output).
 
 ## Troubleshooting
 

--- a/src/auth/authenticator.py
+++ b/src/auth/authenticator.py
@@ -167,7 +167,9 @@ class CachedTokenCredential(TokenCredential):
     def _persist_auth_record(self, credential: DeviceCodeCredential) -> None:
         if self._auth_record_file is None:
             return
-        auth_record = getattr(credential, "_auth_record", None)
+        auth_record = getattr(credential, "authentication_record", None)
+        if auth_record is None:
+            auth_record = getattr(credential, "_auth_record", None)
         if not isinstance(auth_record, AuthenticationRecord):
             return
         if self._auth_record and auth_record.serialize() == self._auth_record.serialize():

--- a/src/auth/authenticator.py
+++ b/src/auth/authenticator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from azure.core.credentials import AccessToken, TokenCredential
-from azure.identity import DeviceCodeCredential, TokenCachePersistenceOptions
+from azure.identity import AuthenticationRecord, DeviceCodeCredential, TokenCachePersistenceOptions
 from msgraph import GraphServiceClient
 
 from src.auth.token_cache import TokenCache
@@ -35,6 +35,7 @@ class CachedTokenCredential(TokenCredential):
         tenant_id: str,
         token_cache: Optional[TokenCache] = None,
         cache_dir: Optional[Path] = None,
+        auth_record_file: Optional[Path] = None,
     ):
         """Initialize the CachedTokenCredential.
 
@@ -43,11 +44,14 @@ class CachedTokenCredential(TokenCredential):
             tenant_id: Azure AD tenant ID
             token_cache: Optional token cache for access token tracking
             cache_dir: Directory for MSAL token cache (defaults to token_cache dir)
+            auth_record_file: File path for persisted authentication record
         """
         self._client_id = client_id
         self._tenant_id = tenant_id
         self._token_cache = token_cache
         self._device_code_credential: Optional[DeviceCodeCredential] = None
+        self._auth_record_file = auth_record_file
+        self._auth_record: Optional[AuthenticationRecord] = None
 
         # Determine cache directory for MSAL token cache
         if cache_dir:
@@ -58,6 +62,9 @@ class CachedTokenCredential(TokenCredential):
             self._cache_dir = Path.home() / ".outmylook"
 
         self._cache_dir.mkdir(parents=True, exist_ok=True)
+        if self._auth_record_file is None:
+            self._auth_record_file = self._cache_dir / "auth_record.json"
+        self._auth_record = self._load_auth_record()
 
     def _get_device_code_credential(self) -> DeviceCodeCredential:
         """Get or create the DeviceCodeCredential with persistent cache.
@@ -78,6 +85,7 @@ class CachedTokenCredential(TokenCredential):
                 client_id=self._client_id,
                 tenant_id=self._tenant_id,
                 cache_persistence_options=cache_options,
+                authentication_record=self._auth_record,
             )
             logger.debug("Created DeviceCodeCredential with persistent token cache")
 
@@ -108,22 +116,13 @@ class CachedTokenCredential(TokenCredential):
         Returns:
             An AccessToken with the token string and expiration time
         """
-        if self._token_cache and self._token_cache.has_valid_token():
-            token_data = self._token_cache.load_token_sync()
-            if token_data:
-                cached_scopes = set(token_data.get("scopes") or [])
-                requested_scopes = set(scopes)
-                access_token = token_data.get("access_token")
-                expires_on = token_data.get("expires_on")
-                if access_token and expires_on and requested_scopes.issubset(cached_scopes):
-                    logger.debug("Using cached access token from TokenCache")
-                    return AccessToken(access_token, expires_on)
-
         # Use Azure SDK's credential which handles caching and refresh
         credential = self._get_device_code_credential()
 
         logger.debug("Requesting token from Azure SDK (will use cache/refresh if available)")
         token = credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs)
+
+        self._persist_auth_record(credential)
 
         # Update our token cache for quick access checks
         if self._token_cache:
@@ -154,6 +153,31 @@ class CachedTokenCredential(TokenCredential):
         except Exception as exc:
             # Don't fail authentication flow if caching fails; just log it.
             logger.debug("Failed to save token to cache: %s", exc)
+
+    def _load_auth_record(self) -> Optional[AuthenticationRecord]:
+        if self._auth_record_file is None or not self._auth_record_file.exists():
+            return None
+        try:
+            data = self._auth_record_file.read_text(encoding="utf-8")
+            return AuthenticationRecord.deserialize(data)
+        except Exception as exc:
+            logger.debug("Failed to load authentication record: %s", exc)
+            return None
+
+    def _persist_auth_record(self, credential: DeviceCodeCredential) -> None:
+        if self._auth_record_file is None:
+            return
+        auth_record = getattr(credential, "_auth_record", None)
+        if not isinstance(auth_record, AuthenticationRecord):
+            return
+        if self._auth_record and auth_record.serialize() == self._auth_record.serialize():
+            return
+        try:
+            self._auth_record_file.parent.mkdir(parents=True, exist_ok=True)
+            self._auth_record_file.write_text(auth_record.serialize(), encoding="utf-8")
+            self._auth_record = auth_record
+        except Exception as exc:
+            logger.debug("Failed to persist authentication record: %s", exc)
 
     async def close(self) -> None:
         """Close the credential."""
@@ -299,6 +323,11 @@ class GraphAuthenticator:
             return False
         return self.token_cache.has_valid_token()
 
+    def _auth_record_path(self) -> Path:
+        if self.token_cache:
+            return Path(self.token_cache.token_file).expanduser().parent / "auth_record.json"
+        return Path.home() / ".outmylook" / "auth_record.json"
+
     async def get_client(self) -> GraphServiceClient:
         """Get authenticated Graph client.
 
@@ -360,6 +389,12 @@ class GraphAuthenticator:
 
         if self.token_cache:
             await self.token_cache.clear()
+        auth_record_file = self._auth_record_path()
+        if auth_record_file.exists():
+            try:
+                auth_record_file.unlink()
+            except Exception as exc:
+                logger.debug("Failed to remove auth record: %s", exc)
 
         self._credential = None
         self._client = None

--- a/src/auth/token_cache.py
+++ b/src/auth/token_cache.py
@@ -99,24 +99,6 @@ class TokenCache:
             logger.warning(f"Failed to load token: {e}")
             return None
 
-    def load_token_sync(self) -> Optional[dict[str, Any]]:
-        """Load token from cache file synchronously.
-
-        Returns:
-            Token data dictionary if exists and readable, None otherwise
-        """
-        if not self.token_file.exists():
-            logger.debug("Token file does not exist")
-            return None
-
-        try:
-            token_data = self._read_token_file()
-            logger.debug("Token loaded from cache (sync)")
-            return token_data
-        except Exception as e:
-            logger.warning(f"Failed to load token: {e}")
-            return None
-
     def _read_token_file(self) -> dict[str, Any]:
         """Read token data from file (synchronous helper).
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -683,7 +683,7 @@ class TestCachedTokenCredential:
 
         mock_device_cred = Mock()
         mock_device_cred.get_token.return_value = Mock(token="new_token", expires_on=123456)
-        mock_device_cred._auth_record = auth_record
+        mock_device_cred.authentication_record = auth_record
 
         with patch.object(credential, "_get_device_code_credential", return_value=mock_device_cred):
             credential.get_token("scope1")

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -78,32 +78,6 @@ def test_load_token_malformed_returns_none(tmp_path: Path) -> None:
     assert data is None
 
 
-def test_load_token_sync_missing_file_returns_none(tmp_path: Path) -> None:
-    """load_token_sync should return None when file is missing."""
-    token_file = tmp_path / "token.json"
-    cache = TokenCache(token_file)
-    assert cache.load_token_sync() is None
-
-
-def test_load_token_sync_reads_file(tmp_path: Path) -> None:
-    """load_token_sync should return token data when available."""
-    token_file = tmp_path / "token.json"
-    token_file.write_text(json.dumps({"access_token": "x", "expires_on": _now_ts()}))
-    cache = TokenCache(token_file)
-    data = cache.load_token_sync()
-    assert data is not None
-    assert data["access_token"] == "x"
-
-
-def test_load_token_sync_read_raises_returns_none(tmp_path: Path) -> None:
-    """load_token_sync should return None when _read_token_file fails."""
-    token_file = tmp_path / "token.json"
-    token_file.write_text(json.dumps({}))
-    cache = TokenCache(token_file)
-    with patch.object(TokenCache, "_read_token_file", side_effect=Exception("boom")):
-        assert cache.load_token_sync() is None
-
-
 def test_save_token_raises_tokencacheerror_on_write_error(tmp_path: Path) -> None:
     token_file = tmp_path / "token.json"
     cache = TokenCache(token_file)


### PR DESCRIPTION
## Summary
- Persist an MSAL authentication record to enable silent token reuse across CLI runs
- Stop using `tokens.json` for authentication; keep it informational and clear auth record on logout
- Update docs to explain MSAL caching and auth record behavior
- Add tests for auth record load/persist and token cache behavior

## Testing
- `./venv/bin/pytest --cov=src --cov-report=term-missing --cov-fail-under=95`
