### PR TITLE
Improve ID output and attachment downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ See the `examples/` directory:
 | `login` | Authenticate with Microsoft Graph | `--config` |
 | `status` | Show auth, database, and attachment status | |
 | `logout` | Clear cached tokens | |
-| `fetch` | Fetch emails from Microsoft Graph | `--folder`, `--limit`, `--skip`, `--from`, `--subject`, `--after`, `--before`, `--read`, `--unread`, `--has-attachments` |
-| `list` | Query stored emails locally | `--limit`, `--offset`, `--from`, `--subject`, `--after`, `--before`, `--read`, `--unread`, `--has-attachments` |
+| `fetch` | Fetch emails from Microsoft Graph | `--folder`, `--limit`, `--skip`, `--from`, `--subject`, `--after`, `--before`, `--read`, `--unread`, `--has-attachments`, `--ids` |
+| `list` | Query stored emails locally | `--limit`, `--offset`, `--from`, `--subject`, `--after`, `--before`, `--read`, `--unread`, `--has-attachments`, `--ids` |
 | `export` | Export stored emails to JSON/CSV | `--format`, filters from `list` |
 | `download` | Download attachments | `<email_id>`, `--attachment`, `--unread`, `--has-attachments` |
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -84,6 +84,7 @@ The command prints a table with received time, sender, subject, read status,
 and attachment presence. Empty folders are handled gracefully.
 If the access token is expired but a refresh token exists, the SDK refreshes
 silently. If authentication fails, run `python -m src.main login`.
+Use `--ids` to print a copy-friendly list of email IDs after the table.
 
 ### Database
 
@@ -151,6 +152,9 @@ python -m src.main list --after 2025-01-01
 
 # Pagination
 python -m src.main list --limit 50 --offset 100
+
+# Copy-friendly IDs
+python -m src.main list --ids
 ```
 
 The table includes the Graph message ID, sender, subject, received time,

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -193,6 +193,13 @@ def test_extract_content_bytes_prefers_content_bytes() -> None:
     assert AttachmentHandler._extract_content_bytes(attachment) == b"hello"
 
 
+def test_extract_content_bytes_decodes_base64_bytes() -> None:
+    """_extract_content_bytes should decode base64 bytes content."""
+    payload = base64.b64encode(b"hello")
+    attachment = SimpleNamespace(content_bytes=payload)
+    assert AttachmentHandler._extract_content_bytes(attachment) == b"hello"
+
+
 def test_extract_content_bytes_handles_content_bytes_bytes() -> None:
     """_extract_content_bytes should accept raw bytes in content_bytes."""
     attachment = SimpleNamespace(content_bytes=b"raw")
@@ -202,6 +209,13 @@ def test_extract_content_bytes_handles_content_bytes_bytes() -> None:
 def test_extract_content_bytes_handles_content_bytes_property() -> None:
     """_extract_content_bytes should decode contentBytes string payloads."""
     payload = base64.b64encode(b"hello").decode("ascii")
+    attachment = SimpleNamespace(contentBytes=payload)
+    assert AttachmentHandler._extract_content_bytes(attachment) == b"hello"
+
+
+def test_extract_content_bytes_decodes_base64_bytes_property() -> None:
+    """_extract_content_bytes should decode base64 bytes contentBytes."""
+    payload = base64.b64encode(b"hello")
     attachment = SimpleNamespace(contentBytes=payload)
     assert AttachmentHandler._extract_content_bytes(attachment) == b"hello"
 


### PR DESCRIPTION
## Summary
- add --ids output for fetch/list to make copy/paste IDs easy
- normalize whitespace in download IDs
- decode base64 attachment payloads when delivered as bytes, with tests
- document --ids usage

## Testing
- pre-commit (black, isort, flake8, mypy, bandit, pip-audit)