### PR TITLE
[codex] Add Outlook email-handling move support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ azure:
   client_id: "your-azure-app-client-id"
   tenant: "common"
   scopes:
-    - "https://graph.microsoft.com/Mail.Read"
+    - "https://graph.microsoft.com/Mail.ReadWrite"
     - "https://graph.microsoft.com/User.Read"
     - "offline_access"
 
@@ -179,7 +179,7 @@ For database setup and migrations, see [Database Guide](docs/DATABASE.md).
 - **Login output is noisy (HTTP polling spam)**: Set `logging.level` to `WARNING` in `config/config.yaml` or run with `LOGGING_LEVEL=WARNING`, then retry `login`.
 - **Token cache/auth record is stale**: Delete `~/.outmylook/auth_record.json` (and optionally `storage.token_file`) and re-run `login`.
 - **SQLite database is locked**: Make sure no other process is using the DB; restart any running fetch/list/export commands.
-- **Attachments not downloading**: Confirm the `Mail.Read` scope is present and the email actually has attachments.
+- **Attachments not downloading**: Confirm the app has a mail scope such as `Mail.ReadWrite` and the email actually has attachments.
 
 ## Project Structure
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -16,7 +16,7 @@ azure:
 
   # Microsoft Graph API scopes (permissions)
   scopes:
-    - "https://graph.microsoft.com/Mail.Read"
+    - "https://graph.microsoft.com/Mail.ReadWrite"
     - "https://graph.microsoft.com/User.Read"
     - "offline_access"
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,7 +301,7 @@ OutMyLook is a Python application for managing Microsoft Outlook emails using th
 
 ### Best Practices
 
-- **Minimal Scopes**: Request only necessary Microsoft Graph API scopes (Mail.Read, User.Read)
+- **Minimal Scopes**: Request only necessary Microsoft Graph API scopes (Mail.ReadWrite, User.Read)
 - **Token Validation**: Check token expiration before use with 5-minute buffer
 - **Error Handling**: Authentication errors caught and reported clearly to users
 - **Logging**: Sensitive data (tokens, credentials) never logged

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -85,7 +85,7 @@ registration to obtain a client ID. No client secret is required.
    - Under **Advanced settings**, enable **Allow public client flows**.
 7. Add Microsoft Graph permissions:
    - Go to **API permissions** -> **Add a permission** -> **Microsoft Graph** -> **Delegated permissions**.
-   - Add: `Mail.Read`, `User.Read`, and `offline_access` (under OpenID permissions).
+   - Add: `Mail.ReadWrite`, `User.Read`, and `offline_access` (under OpenID permissions).
    - If you're in an organization, click **Grant admin consent** if required.
 
 Notes:

--- a/docs/planning/OUTLOOK_PYTHON_DESIGN_1.md
+++ b/docs/planning/OUTLOOK_PYTHON_DESIGN_1.md
@@ -16,7 +16,7 @@ Basic authentication (username/password via IMAP) has been **deprecated for year
 2. **Add API permissions** (delegated – most common for personal use)
 
    - Microsoft Graph → Delegated permissions
-   - `Mail.Read` (minimum)
+   - `Mail.ReadWrite` (recommended if the app needs to modify mail)
    - `offline_access` (recommended → refresh tokens)
    - `User.Read` (usually added automatically)
 
@@ -26,7 +26,7 @@ Basic authentication (username/password via IMAP) has been **deprecated for year
 
    You will also need:
    - Tenant = `common` (for personal Microsoft accounts)
-   - Scopes = `["https://graph.microsoft.com/Mail.Read", "https://graph.microsoft.com/offline_access", "https://graph.microsoft.com/User.Read"]`
+   - Scopes = `["https://graph.microsoft.com/Mail.ReadWrite", "https://graph.microsoft.com/offline_access", "https://graph.microsoft.com/User.Read"]`
 
 4. **Most convenient libraries in 2025**
 

--- a/src/auth/authenticator.py
+++ b/src/auth/authenticator.py
@@ -225,7 +225,7 @@ class GraphAuthenticator:
         self.client_id = client_id
         self.tenant = tenant
         self.scopes = scopes or [
-            "https://graph.microsoft.com/Mail.Read",
+            "https://graph.microsoft.com/Mail.ReadWrite",
             "https://graph.microsoft.com/User.Read",
             "offline_access",
         ]

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -775,8 +775,7 @@ async def _move_async(
         graph_client = await authenticator.get_client()
         email_client = EmailClient(graph_client)
 
-        existing_folder = await email_client.get_folder(destination_value)
-        destination_folder = existing_folder or await email_client.ensure_folder(destination_value)
+        destination_folder = await email_client.resolve_folder(destination_value)
         matches = await _collect_move_candidates(
             email_client=email_client,
             folder=folder,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -22,6 +22,7 @@ from src.config.settings import Settings, get_settings
 from src.database.models import EmailModel
 from src.database.repository import AttachmentRepository, EmailRepository, get_session
 from src.email import EmailClient, EmailFilter
+from src.email.models import Email
 
 app = typer.Typer(help="OutMyLook - Microsoft Outlook email management tool")
 console = Console()
@@ -410,6 +411,35 @@ def download(
     asyncio.run(_download_async(email_id, attachment_id, unread, has_attachments))
 
 
+@app.command()
+def move(
+    destination: Annotated[str, typer.Argument(help="Destination folder name or ID")],
+    folder: Annotated[
+        Optional[str],
+        typer.Option("--folder", "-f", help="Optional source folder. When omitted, search the whole mailbox."),
+    ] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l", help="Batch size for collecting matches")] = 100,
+    from_address: Annotated[Optional[str], typer.Option("--from", help="Filter by sender email address")] = None,
+    subject: Annotated[Optional[str], typer.Option("--subject", help="Filter by subject containing text")] = None,
+    after: Annotated[Optional[str], typer.Option("--after", help="Filter by received date (YYYY-MM-DD or ISO-8601)")] = None,
+    before: Annotated[Optional[str], typer.Option("--before", help="Filter by received date (YYYY-MM-DD or ISO-8601)")] = None,
+    unread: Annotated[bool, typer.Option("--unread", help="Filter to unread emails only")] = False,
+    read: Annotated[bool, typer.Option("--read", help="Filter to read emails only")] = False,
+    has_attachments: Annotated[bool, typer.Option("--has-attachments", help="Filter to emails with attachments")] = False,
+) -> None:
+    """Move matching emails into a destination folder."""
+    email_filter = _build_email_filter(
+        from_address=from_address,
+        subject=subject,
+        after=after,
+        before=before,
+        unread=unread,
+        read=read,
+        has_attachments=has_attachments,
+    )
+    asyncio.run(_move_async(destination, folder, limit, email_filter))
+
+
 @app.command("list")
 def list_emails(
     limit: Annotated[Optional[int], typer.Option("--limit", "-l", help="Max emails to list")] = None,
@@ -720,6 +750,110 @@ async def _download_for_filtered_emails(handler: AttachmentHandler, emails: list
         ),
         level="summary",
     )
+
+
+async def _move_async(
+    destination: str,
+    folder: Optional[str],
+    limit: int,
+    email_filter: Optional[EmailFilter],
+) -> None:
+    """Async implementation of move command."""
+    try:
+        destination_value = destination.strip()
+        if not destination_value:
+            raise typer.BadParameter("Destination folder cannot be empty.")
+        if limit <= 0:
+            raise typer.BadParameter("--limit must be greater than 0.")
+
+        settings = get_settings()
+        _setup_logging(settings)
+        settings.ensure_directories()
+
+        token_cache = TokenCache(settings.storage.token_file)
+        authenticator = GraphAuthenticator.from_settings(settings.azure, token_cache=token_cache)
+        graph_client = await authenticator.get_client()
+        email_client = EmailClient(graph_client)
+
+        existing_folder = await email_client.get_folder(destination_value)
+        destination_folder = existing_folder or await email_client.ensure_folder(destination_value)
+        matches = await _collect_move_candidates(
+            email_client=email_client,
+            folder=folder,
+            limit=limit,
+            email_filter=email_filter,
+            destination_folder_id=destination_folder.id,
+        )
+
+        if not matches:
+            scope = folder or "mailbox"
+            _console_print(
+                Panel.fit(
+                    f"No emails matched the requested filters in '{scope}'.",
+                    title="Move",
+                    border_style="yellow",
+                ),
+                level="summary",
+            )
+            return
+
+        for email in matches:
+            await email_client.move_email(email.id, destination_folder.id)
+
+        _console_print(
+            Panel.fit(
+                f"✓ Moved {len(matches)} email(s) to '{destination_folder.display_name}'.",
+                title="Move",
+                border_style="green",
+            ),
+            level="summary",
+        )
+
+    except AuthenticationError as e:
+        _console_print(
+            Panel.fit(
+                f"Authentication failed\n\n{str(e)}\n\nRun 'outmylook login' to authenticate.",
+                title="Authentication Required",
+                border_style="red",
+            ),
+            level="error",
+        )
+        raise typer.Exit(code=1)
+    except typer.BadParameter:
+        raise
+    except Exception as e:
+        _render_error("Move", "Error moving emails", e)
+        raise typer.Exit(code=1)
+
+
+async def _collect_move_candidates(
+    *,
+    email_client: EmailClient,
+    folder: Optional[str],
+    limit: int,
+    email_filter: Optional[EmailFilter],
+    destination_folder_id: str,
+) -> list[Email]:
+    """Collect all matching emails before moving them."""
+    matches: list[Email] = []
+    offset = 0
+
+    while True:
+        batch = await email_client.list_emails(
+            folder=folder,
+            limit=limit,
+            skip=offset,
+            email_filter=email_filter,
+        )
+        if not batch:
+            break
+
+        matches.extend(email for email in batch if email.folder_id != destination_folder_id)
+        if len(batch) < limit:
+            break
+        offset += len(batch)
+
+    return matches
 
 
 def _build_local_filters(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -24,7 +24,7 @@ class AzureSettings(BaseSettings):
     )
     scopes: List[str] = Field(
         default_factory=lambda: [
-            "https://graph.microsoft.com/Mail.Read",
+            "https://graph.microsoft.com/Mail.ReadWrite",
             "https://graph.microsoft.com/User.Read",
             "offline_access",
         ],

--- a/src/email/client.py
+++ b/src/email/client.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from importlib import import_module
 from typing import Any, Optional, cast
 
+from kiota_abstractions.method import Method
+from kiota_abstractions.request_information import RequestInformation
 from msgraph import GraphServiceClient
 
 from src.database.repository import EmailRepository
@@ -24,16 +27,21 @@ class EmailClient:
 
     async def list_emails(
         self,
-        folder: str = "inbox",
+        folder: Optional[str] = "inbox",
         limit: int = 25,
         skip: int = 0,
         email_filter: Optional[EmailFilter] = None,
     ) -> list[Email]:
-        """Fetch emails from a folder with pagination."""
-        folder_id = await self._resolve_folder_id(folder)
-        messages_request = self._get_folder_messages_request(folder_id)
+        """Fetch emails from a folder or the whole mailbox with pagination."""
+        folder_id = await self._resolve_folder_id(folder) if folder is not None else None
+        messages_request = self._get_messages_request(folder_id)
         filter_query = email_filter.build() if email_filter else None
-        request_configuration = self._build_messages_request_config(limit=limit, skip=skip, filter_query=filter_query)
+        request_configuration = self._build_messages_request_config(
+            limit=limit,
+            skip=skip,
+            filter_query=filter_query,
+            include_orderby=folder_id is not None,
+        )
 
         if request_configuration is not None:
             response = await messages_request.get(request_configuration=request_configuration)
@@ -50,6 +58,52 @@ class EmailClient:
         if self._email_repository and emails:
             await self._email_repository.save_many(emails)
         return emails
+
+    async def ensure_folder(self, display_name: str) -> MailFolder:
+        """Return an existing top-level folder or create it when missing."""
+        normalized = display_name.strip()
+        if not normalized:
+            raise ValueError("Folder name cannot be empty.")
+
+        folders = await self.list_folders()
+        for folder in folders:
+            if folder.display_name.strip().lower() == normalized.lower():
+                return folder
+
+        created = await self._create_folder(normalized)
+        if created.display_name.strip().lower() == normalized.lower():
+            return created
+
+        raise ValueError(f"Folder '{normalized}' was created but returned unexpected metadata.")
+
+    async def get_folder(self, folder_id: str) -> Optional[MailFolder]:
+        """Return a folder by Graph ID when it exists."""
+        normalized = folder_id.strip()
+        if not normalized:
+            raise ValueError("Folder ID cannot be empty.")
+
+        mail_folders = self._graph_client.me.mail_folders
+        if hasattr(mail_folders, "by_id"):
+            folder_request = mail_folders.by_id(normalized)
+        else:
+            folder_request = mail_folders.by_mail_folder_id(normalized)
+
+        try:
+            folder = await folder_request.get()
+        except Exception:
+            return None
+        if folder is None:
+            return None
+        return MailFolder.from_graph_folder(folder)
+
+    async def move_email(self, message_id: str, destination_folder: str) -> None:
+        """Move a message into the destination folder."""
+        destination_id = await self._resolve_folder_id(destination_folder)
+        await self._post_json(
+            "{+baseurl}/me/messages/{message%2Did}/move",
+            {"message%2Did": message_id},
+            {"destinationId": destination_id},
+        )
 
     async def get_email(self, message_id: str) -> Email:
         """Fetch a single email by ID."""
@@ -101,6 +155,11 @@ class EmailClient:
 
         return folder
 
+    def _get_messages_request(self, folder_id: Optional[str]) -> Any:
+        if folder_id is None:
+            return self._graph_client.me.messages
+        return self._get_folder_messages_request(folder_id)
+
     def _get_folder_messages_request(self, folder_id: str) -> Any:
         mail_folders = self._graph_client.me.mail_folders
         if hasattr(mail_folders, "by_id"):
@@ -109,7 +168,55 @@ class EmailClient:
             folder_request = mail_folders.by_mail_folder_id(folder_id)
         return folder_request.messages
 
-    def _build_messages_request_config(self, limit: int, skip: int, filter_query: Optional[str] = None) -> Optional[Any]:
+    async def _create_folder(self, display_name: str) -> MailFolder:
+        response = await self._post_json(
+            "{+baseurl}/me/mailFolders",
+            {},
+            {"displayName": display_name},
+        )
+        if not response:
+            raise ValueError(f"Folder '{display_name}' was created but Microsoft Graph returned no payload.")
+        return MailFolder.from_graph_folder(response)
+
+    async def _post_json(
+        self,
+        url_template: str,
+        path_parameters: dict[str, str],
+        payload: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        request_adapter = getattr(self._graph_client, "request_adapter", None)
+        if request_adapter is None:
+            raise ValueError("Graph client does not expose a request adapter.")
+
+        request_info = RequestInformation(
+            Method.POST,
+            url_template,
+            path_parameters,
+        )
+        request_info.headers.try_add("Accept", "application/json")
+        request_info.set_stream_content(
+            json.dumps(payload).encode("utf-8"),
+            "application/json",
+        )
+        response = await request_adapter.send_primitive_async(request_info, "bytes", None)
+        if response is None:
+            return None
+        if isinstance(response, bytearray):
+            response = bytes(response)
+        if isinstance(response, bytes):
+            text = response.decode("utf-8").strip()
+            if not text:
+                return None
+            return cast(dict[str, Any], json.loads(text))
+        raise TypeError("Unsupported response payload type")
+
+    def _build_messages_request_config(
+        self,
+        limit: int,
+        skip: int,
+        filter_query: Optional[str] = None,
+        include_orderby: bool = True,
+    ) -> Optional[Any]:
         builder = self._import_builder(
             [
                 "msgraph.generated.users.item.mail_folders.item.messages.messages_request_builder",
@@ -136,7 +243,7 @@ class EmailClient:
                 "hasAttachments",
                 "parentFolderId",
             ],
-            orderby=["receivedDateTime desc"],
+            orderby=["receivedDateTime desc"] if include_orderby else None,
         )
         return builder.MessagesRequestBuilderGetRequestConfiguration(query_parameters=query_params)
 
@@ -149,6 +256,7 @@ class EmailClient:
             return None
 
         query_params = builder.MailFoldersRequestBuilderGetQueryParameters(
+            top=200,
             select=[
                 "id",
                 "displayName",
@@ -156,7 +264,7 @@ class EmailClient:
                 "childFolderCount",
                 "totalItemCount",
                 "unreadItemCount",
-            ]
+            ],
         )
         return builder.MailFoldersRequestBuilderGetRequestConfiguration(query_parameters=query_params)
 

--- a/src/email/client.py
+++ b/src/email/client.py
@@ -96,6 +96,30 @@ class EmailClient:
             return None
         return MailFolder.from_graph_folder(folder)
 
+    async def resolve_folder(self, folder: str) -> MailFolder:
+        """Resolve a folder name or ID to concrete folder metadata.
+
+        Well-known aliases such as ``deleted`` and ``sent`` should resolve to
+        their built-in Graph folders instead of being treated as custom names.
+        When no existing folder can be resolved, create a new top-level folder
+        using the provided display name.
+        """
+        normalized = folder.strip()
+        if not normalized:
+            raise ValueError("Folder cannot be empty.")
+
+        existing_folder = await self.get_folder(normalized)
+        if existing_folder is not None:
+            return existing_folder
+
+        resolved_id = await self._resolve_folder_id(normalized)
+        if resolved_id != normalized:
+            resolved_folder = await self.get_folder(resolved_id)
+            if resolved_folder is not None:
+                return resolved_folder
+
+        return await self.ensure_folder(normalized)
+
     async def move_email(self, message_id: str, destination_folder: str) -> None:
         """Move a message into the destination folder."""
         destination_id = await self._resolve_folder_id(destination_folder)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -35,7 +35,7 @@ class TestTokenCache:
         """Test saving token to cache."""
         access_token = "test_token_123"
         expires_on = int(datetime.now(timezone.utc).timestamp()) + 3600
-        scopes = ["Mail.Read", "User.Read"]
+        scopes = ["Mail.ReadWrite", "User.Read"]
 
         await token_cache.save_token(access_token, expires_on, scopes)
 
@@ -60,7 +60,7 @@ class TestTokenCache:
         test_data = {
             "access_token": "test_token",
             "expires_on": int(datetime.now(timezone.utc).timestamp()) + 3600,
-            "scopes": ["Mail.Read"],
+            "scopes": ["Mail.ReadWrite"],
             "cached_at": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -94,7 +94,7 @@ class TestTokenCache:
         expired_data = {
             "access_token": "token",
             "expires_on": int(datetime.now(timezone.utc).timestamp()) - 100,  # Expired
-            "scopes": ["Mail.Read"],
+            "scopes": ["Mail.ReadWrite"],
         }
 
         with open(token_file, "w") as f:
@@ -108,7 +108,7 @@ class TestTokenCache:
         expires_soon_data = {
             "access_token": "token",
             "expires_on": int(datetime.now(timezone.utc).timestamp()) + 120,
-            "scopes": ["Mail.Read"],
+            "scopes": ["Mail.ReadWrite"],
         }
 
         with open(token_file, "w") as f:
@@ -121,7 +121,7 @@ class TestTokenCache:
         valid_data = {
             "access_token": "token",
             "expires_on": int(datetime.now(timezone.utc).timestamp()) + 3600,  # 1 hour
-            "scopes": ["Mail.Read"],
+            "scopes": ["Mail.ReadWrite"],
         }
 
         with open(token_file, "w") as f:
@@ -163,7 +163,7 @@ class TestTokenCache:
         valid_data = {
             "access_token": "test_token_123",
             "expires_on": int(datetime.now(timezone.utc).timestamp()) + 3600,
-            "scopes": ["Mail.Read"],
+            "scopes": ["Mail.ReadWrite"],
         }
 
         with open(token_file, "w") as f:
@@ -187,7 +187,7 @@ class TestTokenCache:
         valid_data = {
             "access_token": "token",
             "expires_on": expires_on,
-            "scopes": ["Mail.Read", "User.Read"],
+            "scopes": ["Mail.ReadWrite", "User.Read"],
             "cached_at": cached_at,
         }
 
@@ -199,7 +199,7 @@ class TestTokenCache:
         assert info is not None
         assert info["expires_on"] == expires_on
         assert "expires_at" in info
-        assert info["scopes"] == ["Mail.Read", "User.Read"]
+        assert info["scopes"] == ["Mail.ReadWrite", "User.Read"]
         assert info["cached_at"] == cached_at
         assert info["seconds_until_expiry"] > 0
 
@@ -249,7 +249,7 @@ class TestGraphAuthenticator:
         return AzureSettings(
             client_id="test-client-id",
             tenant="common",
-            scopes=["Mail.Read", "User.Read", "offline_access"],
+            scopes=["Mail.ReadWrite", "User.Read", "offline_access"],
         )
 
     @pytest.fixture
@@ -277,13 +277,13 @@ class TestGraphAuthenticator:
         """Test GraphAuthenticator initialization."""
         assert authenticator.client_id == "test-client-id"
         assert authenticator.tenant == "common"
-        assert "Mail.Read" in authenticator.scopes
+        assert "Mail.ReadWrite" in authenticator.scopes
         assert authenticator.token_cache is not None
 
     def test_init_default_scopes(self) -> None:
         """Test GraphAuthenticator with default scopes."""
         auth = GraphAuthenticator(client_id="test-client-id")
-        assert "https://graph.microsoft.com/Mail.Read" in auth.scopes
+        assert "https://graph.microsoft.com/Mail.ReadWrite" in auth.scopes
         assert "https://graph.microsoft.com/User.Read" in auth.scopes
         assert "offline_access" in auth.scopes
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,7 +201,7 @@ def test_status_renders_panel() -> None:
     mock_token_cache = MagicMock()
     mock_token_cache.has_valid_token.return_value = True
     mock_token_cache.get_token_info = AsyncMock(
-        return_value={"expires_at": "2026-01-01T00:00:00+00:00", "scopes": ["Mail.Read"]}
+        return_value={"expires_at": "2026-01-01T00:00:00+00:00", "scopes": ["Mail.ReadWrite"]}
     )
     mock_token_cache.is_token_expiring_soon.return_value = False
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -624,7 +624,7 @@ def test_download_filters_no_matches() -> None:
 
 
 def test_move_moves_all_matches_and_skips_already_in_destination() -> None:
-    """move should collect matches, create the folder if needed, and move each candidate."""
+    """move should resolve the destination folder and move each candidate."""
     mock_token_cache = MagicMock()
 
     fake_client = MagicMock()
@@ -653,8 +653,7 @@ def test_move_moves_all_matches_and_skips_already_in_destination() -> None:
         folder_id="folder-dst",
     )
     email_client_instance = MagicMock()
-    email_client_instance.get_folder = AsyncMock(return_value=None)
-    email_client_instance.ensure_folder = AsyncMock(return_value=destination_folder)
+    email_client_instance.resolve_folder = AsyncMock(return_value=destination_folder)
     email_client_instance.list_emails = AsyncMock(side_effect=[[email_one, email_two], []])
     email_client_instance.move_email = AsyncMock()
 
@@ -669,7 +668,7 @@ def test_move_moves_all_matches_and_skips_already_in_destination() -> None:
 
         commands.move(destination="Pre-Delete Temp", from_address="ci_activity@noreply.github.com")
 
-        email_client_instance.ensure_folder.assert_awaited_once_with("Pre-Delete Temp")
+        email_client_instance.resolve_folder.assert_awaited_once_with("Pre-Delete Temp")
         email_client_instance.move_email.assert_awaited_once_with("email-1", "folder-dst")
         mock_console.print.assert_called()
 
@@ -684,8 +683,7 @@ def test_move_no_matches_reports_summary() -> None:
 
     destination_folder = MagicMock(id="folder-dst", display_name="Pre-Delete Temp")
     email_client_instance = MagicMock()
-    email_client_instance.get_folder = AsyncMock(return_value=None)
-    email_client_instance.ensure_folder = AsyncMock(return_value=destination_folder)
+    email_client_instance.resolve_folder = AsyncMock(return_value=destination_folder)
     email_client_instance.list_emails = AsyncMock(return_value=[])
     email_client_instance.move_email = AsyncMock()
 
@@ -714,8 +712,7 @@ def test_move_uses_existing_folder_id_without_creating_new_folder() -> None:
 
     destination_folder = MagicMock(id="folder-dst", display_name="Nested Folder")
     email_client_instance = MagicMock()
-    email_client_instance.get_folder = AsyncMock(return_value=destination_folder)
-    email_client_instance.ensure_folder = AsyncMock()
+    email_client_instance.resolve_folder = AsyncMock(return_value=destination_folder)
     email_client_instance.list_emails = AsyncMock(return_value=[])
     email_client_instance.move_email = AsyncMock()
 
@@ -730,8 +727,37 @@ def test_move_uses_existing_folder_id_without_creating_new_folder() -> None:
 
         commands.move(destination="AQMk-folder-id", from_address="sender@example.com")
 
-        email_client_instance.get_folder.assert_awaited_once_with("AQMk-folder-id")
-        email_client_instance.ensure_folder.assert_not_awaited()
+        email_client_instance.resolve_folder.assert_awaited_once_with("AQMk-folder-id")
+        mock_console.print.assert_called()
+
+
+def test_move_uses_well_known_folder_alias_without_creating_custom_folder() -> None:
+    """move should resolve well-known aliases like deleted via resolve_folder."""
+    mock_token_cache = MagicMock()
+
+    fake_client = MagicMock()
+    fake_authenticator = MagicMock()
+    fake_authenticator.get_client = AsyncMock(return_value=fake_client)
+
+    destination_folder = MagicMock(id="deleteditems", display_name="Deleted Items")
+    email_client_instance = MagicMock()
+    email_client_instance.resolve_folder = AsyncMock(return_value=destination_folder)
+    email_client_instance.list_emails = AsyncMock(return_value=[])
+    email_client_instance.move_email = AsyncMock()
+
+    with (
+        patch("src.cli.commands.get_settings", return_value=make_settings()),
+        patch("src.cli.commands.TokenCache", return_value=mock_token_cache),
+        patch("src.cli.commands.GraphAuthenticator", autospec=True) as mock_graph_auth,
+        patch("src.cli.commands.EmailClient", return_value=email_client_instance),
+        patch("src.cli.commands.console") as mock_console,
+    ):
+        mock_graph_auth.from_settings.return_value = fake_authenticator
+
+        commands.move(destination="deleted", from_address="sender@example.com")
+
+        email_client_instance.resolve_folder.assert_awaited_once_with("deleted")
+        email_client_instance.move_email.assert_not_awaited()
         mock_console.print.assert_called()
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -623,6 +623,118 @@ def test_download_filters_no_matches() -> None:
         mock_console.print.assert_called()
 
 
+def test_move_moves_all_matches_and_skips_already_in_destination() -> None:
+    """move should collect matches, create the folder if needed, and move each candidate."""
+    mock_token_cache = MagicMock()
+
+    fake_client = MagicMock()
+    fake_authenticator = MagicMock()
+    fake_authenticator.get_client = AsyncMock(return_value=fake_client)
+
+    destination_folder = MagicMock(id="folder-dst", display_name="Pre-Delete Temp")
+    email_one = Email(
+        id="email-1",
+        subject="CI",
+        sender=EmailAddress(address="ci_activity@noreply.github.com"),
+        received_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        body_preview="",
+        is_read=False,
+        has_attachments=False,
+        folder_id="inbox",
+    )
+    email_two = Email(
+        id="email-2",
+        subject="CI",
+        sender=EmailAddress(address="ci_activity@noreply.github.com"),
+        received_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        body_preview="",
+        is_read=False,
+        has_attachments=False,
+        folder_id="folder-dst",
+    )
+    email_client_instance = MagicMock()
+    email_client_instance.get_folder = AsyncMock(return_value=None)
+    email_client_instance.ensure_folder = AsyncMock(return_value=destination_folder)
+    email_client_instance.list_emails = AsyncMock(side_effect=[[email_one, email_two], []])
+    email_client_instance.move_email = AsyncMock()
+
+    with (
+        patch("src.cli.commands.get_settings", return_value=make_settings()),
+        patch("src.cli.commands.TokenCache", return_value=mock_token_cache),
+        patch("src.cli.commands.GraphAuthenticator", autospec=True) as mock_graph_auth,
+        patch("src.cli.commands.EmailClient", return_value=email_client_instance),
+        patch("src.cli.commands.console") as mock_console,
+    ):
+        mock_graph_auth.from_settings.return_value = fake_authenticator
+
+        commands.move(destination="Pre-Delete Temp", from_address="ci_activity@noreply.github.com")
+
+        email_client_instance.ensure_folder.assert_awaited_once_with("Pre-Delete Temp")
+        email_client_instance.move_email.assert_awaited_once_with("email-1", "folder-dst")
+        mock_console.print.assert_called()
+
+
+def test_move_no_matches_reports_summary() -> None:
+    """move should report when no emails match the requested filters."""
+    mock_token_cache = MagicMock()
+
+    fake_client = MagicMock()
+    fake_authenticator = MagicMock()
+    fake_authenticator.get_client = AsyncMock(return_value=fake_client)
+
+    destination_folder = MagicMock(id="folder-dst", display_name="Pre-Delete Temp")
+    email_client_instance = MagicMock()
+    email_client_instance.get_folder = AsyncMock(return_value=None)
+    email_client_instance.ensure_folder = AsyncMock(return_value=destination_folder)
+    email_client_instance.list_emails = AsyncMock(return_value=[])
+    email_client_instance.move_email = AsyncMock()
+
+    with (
+        patch("src.cli.commands.get_settings", return_value=make_settings()),
+        patch("src.cli.commands.TokenCache", return_value=mock_token_cache),
+        patch("src.cli.commands.GraphAuthenticator", autospec=True) as mock_graph_auth,
+        patch("src.cli.commands.EmailClient", return_value=email_client_instance),
+        patch("src.cli.commands.console") as mock_console,
+    ):
+        mock_graph_auth.from_settings.return_value = fake_authenticator
+
+        commands.move(destination="Pre-Delete Temp", from_address="ci_activity@noreply.github.com")
+
+        email_client_instance.move_email.assert_not_awaited()
+        mock_console.print.assert_called()
+
+
+def test_move_uses_existing_folder_id_without_creating_new_folder() -> None:
+    """move should treat an existing Graph folder ID as the destination."""
+    mock_token_cache = MagicMock()
+
+    fake_client = MagicMock()
+    fake_authenticator = MagicMock()
+    fake_authenticator.get_client = AsyncMock(return_value=fake_client)
+
+    destination_folder = MagicMock(id="folder-dst", display_name="Nested Folder")
+    email_client_instance = MagicMock()
+    email_client_instance.get_folder = AsyncMock(return_value=destination_folder)
+    email_client_instance.ensure_folder = AsyncMock()
+    email_client_instance.list_emails = AsyncMock(return_value=[])
+    email_client_instance.move_email = AsyncMock()
+
+    with (
+        patch("src.cli.commands.get_settings", return_value=make_settings()),
+        patch("src.cli.commands.TokenCache", return_value=mock_token_cache),
+        patch("src.cli.commands.GraphAuthenticator", autospec=True) as mock_graph_auth,
+        patch("src.cli.commands.EmailClient", return_value=email_client_instance),
+        patch("src.cli.commands.console") as mock_console,
+    ):
+        mock_graph_auth.from_settings.return_value = fake_authenticator
+
+        commands.move(destination="AQMk-folder-id", from_address="sender@example.com")
+
+        email_client_instance.get_folder.assert_awaited_once_with("AQMk-folder-id")
+        email_client_instance.ensure_folder.assert_not_awaited()
+        mock_console.print.assert_called()
+
+
 def test_build_email_filter_returns_none_when_no_filters() -> None:
     """_build_email_filter should return None when no filters are provided."""
     result = commands._build_email_filter(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -61,7 +61,7 @@ def test_status_authenticated_shows_token_info() -> None:
         return_value={
             "expires_at": "2026-01-01T00:00:00+00:00",
             "seconds_until_expiry": 3600,
-            "scopes": ["Mail.Read"],
+            "scopes": ["Mail.ReadWrite"],
             "cached_at": "2026-01-01T00:00:00+00:00",
         }
     )
@@ -133,7 +133,7 @@ def test_login_already_authenticated_no_reauth() -> None:
     mock_token_cache = MagicMock()
     mock_token_cache.has_valid_token.return_value = True
     mock_token_cache.get_token_info = AsyncMock(
-        return_value={"expires_at": "2026-01-01T00:00:00+00:00", "scopes": ["Mail.Read"]}
+        return_value={"expires_at": "2026-01-01T00:00:00+00:00", "scopes": ["Mail.ReadWrite"]}
     )
 
     with (
@@ -153,7 +153,7 @@ def test_login_already_authenticated_reauth_and_success() -> None:
     mock_token_cache = MagicMock()
     mock_token_cache.has_valid_token.return_value = True
     mock_token_cache.get_token_info = AsyncMock(
-        return_value={"expires_at": "2026-01-01T00:00:00+00:00", "scopes": ["Mail.Read"]}
+        return_value={"expires_at": "2026-01-01T00:00:00+00:00", "scopes": ["Mail.ReadWrite"]}
     )
     mock_token_cache.clear = AsyncMock()
 
@@ -240,7 +240,7 @@ def test_status_expiring_soon_shows_note() -> None:
         return_value={
             "expires_at": "2026-01-01T00:00:00+00:00",
             "seconds_until_expiry": 10,
-            "scopes": ["Mail.Read"],
+            "scopes": ["Mail.ReadWrite"],
             "cached_at": "2026-01-01T00:00:00+00:00",
         }
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ class TestAzureSettings:
         assert settings.client_id == ""
         assert settings.tenant == "common"
         assert len(settings.scopes) == 3
-        assert "https://graph.microsoft.com/Mail.Read" in settings.scopes
+        assert "https://graph.microsoft.com/Mail.ReadWrite" in settings.scopes
         assert "https://graph.microsoft.com/User.Read" in settings.scopes
         assert "offline_access" in settings.scopes
 

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -6,6 +6,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from kiota_abstractions.method import Method
 
 from src.email.client import EmailClient
 from src.email.filters import EmailFilter
@@ -165,6 +166,41 @@ async def test_list_emails_without_request_config_uses_default_get() -> None:
 
     with patch.object(client, "_build_messages_request_config", return_value=None):
         emails = await client.list_emails(folder="Inbox", limit=10, skip=0)
+
+    messages_request.get.assert_awaited_once_with()
+    assert len(emails) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_emails_without_folder_uses_mailbox_messages() -> None:
+    """list_emails should use the mailbox messages collection when folder is None."""
+    graph_client = MagicMock()
+
+    message = MagicMock()
+    message.id = "msg-12"
+    message.subject = "Hello"
+    message.sender = MagicMock()
+    message.sender.email_address = MagicMock()
+    message.sender.email_address.address = "alice@example.com"
+    message.sender.email_address.name = "Alice"
+    message.received_date_time = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    message.body_preview = "Preview"
+    message.body = MagicMock(content="Body")
+    message.is_read = False
+    message.has_attachments = True
+    message.parent_folder_id = "inbox"
+
+    response = MagicMock()
+    response.value = [message]
+
+    messages_request = MagicMock()
+    messages_request.get = AsyncMock(return_value=response)
+    graph_client.me.messages = messages_request
+
+    client = EmailClient(graph_client)
+
+    with patch.object(client, "_build_messages_request_config", return_value=None):
+        emails = await client.list_emails(folder=None, limit=10, skip=0)
 
     messages_request.get.assert_awaited_once_with()
     assert len(emails) == 1
@@ -397,6 +433,91 @@ def test_get_folder_messages_request_uses_by_mail_folder_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ensure_folder_returns_existing_match_case_insensitive() -> None:
+    """ensure_folder should reuse an existing folder when names match."""
+    client = EmailClient(MagicMock())
+    folder = MailFolder(id="folder-1", display_name="Pre-Delete")
+
+    with patch.object(client, "list_folders", AsyncMock(return_value=[folder])):
+        resolved = await client.ensure_folder("pre-delete")
+
+    assert resolved is folder
+
+
+@pytest.mark.asyncio
+async def test_ensure_folder_creates_and_refetches() -> None:
+    """ensure_folder should create missing folders and return the created folder."""
+    client = EmailClient(MagicMock())
+    created_folder = MailFolder(id="folder-2", display_name="Pre-Delete")
+
+    with (
+        patch.object(client, "list_folders", AsyncMock(return_value=[])),
+        patch.object(client, "_create_folder", AsyncMock(return_value=created_folder)) as create_folder,
+    ):
+        resolved = await client.ensure_folder("Pre-Delete")
+
+    create_folder.assert_awaited_once_with("Pre-Delete")
+    assert resolved == created_folder
+
+
+@pytest.mark.asyncio
+async def test_move_email_posts_move_request() -> None:
+    """move_email should post a move request with the resolved destination ID."""
+    request_adapter = MagicMock()
+    request_adapter.send_primitive_async = AsyncMock(return_value=b"{}")
+    graph_client = MagicMock(request_adapter=request_adapter)
+    client = EmailClient(graph_client)
+
+    with patch.object(client, "_resolve_folder_id", AsyncMock(return_value="folder-123")):
+        await client.move_email("message-1", "Archive")
+
+    request_info = request_adapter.send_primitive_async.await_args.args[0]
+    assert request_info.http_method == Method.POST
+    assert request_info.url_template == "{+baseurl}/me/messages/{message%2Did}/move"
+    assert request_info.path_parameters["message%2Did"] == "message-1"
+    assert b"folder-123" in request_info.content
+
+
+@pytest.mark.asyncio
+async def test_get_folder_returns_model() -> None:
+    """get_folder should fetch and map a folder by Graph ID."""
+    graph_client = MagicMock()
+
+    folder_payload = MagicMock()
+    folder_payload.id = "folder-1"
+    folder_payload.display_name = "Nested"
+    folder_payload.parent_folder_id = "parent-1"
+    folder_payload.child_folder_count = 0
+    folder_payload.total_item_count = 4
+    folder_payload.unread_item_count = 1
+
+    folder_request = MagicMock()
+    folder_request.get = AsyncMock(return_value=folder_payload)
+    graph_client.me.mail_folders.by_id.return_value = folder_request
+
+    client = EmailClient(graph_client)
+    folder = await client.get_folder("folder-1")
+
+    graph_client.me.mail_folders.by_id.assert_called_with("folder-1")
+    assert folder is not None
+    assert folder.id == "folder-1"
+
+
+@pytest.mark.asyncio
+async def test_get_folder_returns_none_on_error() -> None:
+    """get_folder should return None when the folder lookup fails."""
+    graph_client = MagicMock()
+    folder_request = MagicMock()
+    folder_request.get = AsyncMock(side_effect=RuntimeError("missing"))
+    graph_client.me.mail_folders.by_id.return_value = folder_request
+
+    client = EmailClient(graph_client)
+    folder = await client.get_folder("folder-1")
+
+    assert folder is None
+
+
+@pytest.mark.asyncio
 async def test_resolve_folder_id_returns_well_known() -> None:
     """_resolve_folder_id should map well-known folders."""
     client = EmailClient(MagicMock())
@@ -499,7 +620,12 @@ async def test_list_emails_passes_filter_query() -> None:
     with patch.object(client, "_build_messages_request_config", return_value=config) as mock_config:
         await client.list_emails(folder="Inbox", limit=5, skip=0, email_filter=email_filter)
 
-    mock_config.assert_called_with(limit=5, skip=0, filter_query=email_filter.build())
+    mock_config.assert_called_with(
+        limit=5,
+        skip=0,
+        filter_query=email_filter.build(),
+        include_orderby=True,
+    )
 
 
 def test_build_folders_request_config_returns_none_when_builder_missing() -> None:

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -479,6 +479,64 @@ async def test_move_email_posts_move_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_folder_prefers_existing_graph_folder_id() -> None:
+    """resolve_folder should return an existing folder when the input is a Graph ID."""
+    client = EmailClient(MagicMock())
+    folder = MailFolder(id="folder-1", display_name="Nested")
+
+    with (
+        patch.object(client, "get_folder", AsyncMock(return_value=folder)) as get_folder,
+        patch.object(client, "_resolve_folder_id", AsyncMock()) as resolve_folder_id,
+        patch.object(client, "ensure_folder", AsyncMock()) as ensure_folder,
+    ):
+        resolved = await client.resolve_folder("folder-1")
+
+    get_folder.assert_awaited_once_with("folder-1")
+    resolve_folder_id.assert_not_awaited()
+    ensure_folder.assert_not_awaited()
+    assert resolved is folder
+
+
+@pytest.mark.asyncio
+async def test_resolve_folder_uses_well_known_alias_before_creating() -> None:
+    """resolve_folder should use resolved well-known aliases before creating folders."""
+    client = EmailClient(MagicMock())
+    deleted_items = MailFolder(id="deleteditems", display_name="Deleted Items")
+
+    with (
+        patch.object(client, "get_folder", AsyncMock(side_effect=[None, deleted_items])) as get_folder,
+        patch.object(client, "_resolve_folder_id", AsyncMock(return_value="deleteditems")) as resolve_folder_id,
+        patch.object(client, "ensure_folder", AsyncMock()) as ensure_folder,
+    ):
+        resolved = await client.resolve_folder("deleted")
+
+    assert get_folder.await_args_list[0].args == ("deleted",)
+    assert get_folder.await_args_list[1].args == ("deleteditems",)
+    resolve_folder_id.assert_awaited_once_with("deleted")
+    ensure_folder.assert_not_awaited()
+    assert resolved is deleted_items
+
+
+@pytest.mark.asyncio
+async def test_resolve_folder_creates_when_no_existing_folder_matches() -> None:
+    """resolve_folder should create a folder only when nothing resolves."""
+    client = EmailClient(MagicMock())
+    created_folder = MailFolder(id="folder-2", display_name="Pre-Delete")
+
+    with (
+        patch.object(client, "get_folder", AsyncMock(return_value=None)) as get_folder,
+        patch.object(client, "_resolve_folder_id", AsyncMock(return_value="Pre-Delete")) as resolve_folder_id,
+        patch.object(client, "ensure_folder", AsyncMock(return_value=created_folder)) as ensure_folder,
+    ):
+        resolved = await client.resolve_folder("Pre-Delete")
+
+    get_folder.assert_awaited_once_with("Pre-Delete")
+    resolve_folder_id.assert_awaited_once_with("Pre-Delete")
+    ensure_folder.assert_awaited_once_with("Pre-Delete")
+    assert resolved is created_folder
+
+
+@pytest.mark.asyncio
 async def test_get_folder_returns_model() -> None:
     """get_folder should fetch and map a folder by Graph ID."""
     graph_client = MagicMock()

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -20,7 +20,7 @@ def test_save_and_load_token(tmp_path: Path) -> None:
     cache = TokenCache(token_file)
 
     expires_on = _now_ts() + 3600
-    asyncio.run(cache.save_token("abc123", expires_on, ["Mail.Read"]))
+    asyncio.run(cache.save_token("abc123", expires_on, ["Mail.ReadWrite"]))
 
     # File should exist
     assert token_file.exists()


### PR DESCRIPTION
## What changed

- add message move support for inbox-management workflows
- update the default Graph mail scope to `Mail.ReadWrite`
- keep folder-ID based moves working correctly for nested Outlook folders

## Why

Inbox organization work needed a low-overhead way to reuse the existing Outlook authentication state, move existing messages, and avoid creating incorrect folders when the destination is nested.

## Impact

- `OutMyLook` can now move matching messages directly from the CLI
- nested folder destinations are handled by real Graph folder IDs
- the default mail scope matches the write operations the tool now performs

## Validation

- `./venv/bin/pytest tests/test_email_client.py tests/test_commands.py`
- result: `67 passed`
