### PR TITLE
ci: consolidate jobs (3.12-only, coverage in test, validate in lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: 'pip'
 
     - name: Install dependencies
@@ -47,13 +47,32 @@ jobs:
         # Uses settings from pyproject.toml [tool.mypy]
         mypy src/ --explicit-package-bases
 
+    - name: Validate YAML configuration files
+      run: |
+        python -c "
+        import yaml
+        import sys
+
+        try:
+            with open('config/config.example.yaml', 'r') as f:
+                yaml.safe_load(f)
+            print('config.example.yaml is valid')
+        except Exception as e:
+            print(f'config.example.yaml is invalid: {e}')
+            sys.exit(1)
+        "
+
+    - name: Check Python syntax
+      run: |
+        find src -name '*.py' -exec python -m py_compile {} +
+
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
 
     steps:
     - name: Checkout code
@@ -73,7 +92,7 @@ jobs:
 
     - name: Run unit tests
       run: |
-        pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing
+        pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing --cov-report=html --cov-fail-under=95
 
     - name: Upload coverage reports
       if: matrix.python-version == '3.12'
@@ -82,38 +101,6 @@ jobs:
         file: ./coverage.xml
         fail_ci_if_error: false
       continue-on-error: true
-
-  coverage:
-    name: Coverage Check (95% target)
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-        cache: 'pip'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov pytest-mock pytest-asyncio
-        pip install -r requirements.txt
-
-    - name: Run tests with coverage
-      run: |
-        pytest tests/ -v --cov=src --cov-report=term-missing --cov-report=html --cov-fail-under=95
-
-    - name: Upload coverage HTML report
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: coverage-report
-        path: htmlcov/
-        retention-days: 14
 
   security:
     name: Security Checks
@@ -146,49 +133,10 @@ jobs:
         # pip-audit checks for known vulnerabilities in installed packages
         pip-audit --requirement requirements.txt
 
-  validate-config:
-    name: Validate Configuration
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-        cache: 'pip'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install PyYAML
-        pip install -r requirements.txt
-
-    - name: Validate YAML configuration files
-      run: |
-        python -c "
-        import yaml
-        import sys
-
-        try:
-            with open('config/config.example.yaml', 'r') as f:
-                yaml.safe_load(f)
-            print('config.example.yaml is valid')
-        except Exception as e:
-            print(f'config.example.yaml is invalid: {e}')
-            sys.exit(1)
-        "
-
-    - name: Check Python syntax
-      run: |
-        find src -name '*.py' -exec python -m py_compile {} +
-
   build-status:
     name: CI Status Check
     runs-on: ubuntu-latest
-    needs: [lint, test, coverage, security, validate-config]
+    needs: [lint, test, security]
     if: always()
 
     steps:
@@ -202,16 +150,8 @@ jobs:
           echo "Tests failed"
           exit 1
         fi
-        if [ "${{ needs.coverage.result }}" != "success" ]; then
-          echo "Coverage check failed (95% target)"
-          exit 1
-        fi
         if [ "${{ needs.security.result }}" != "success" ]; then
           echo "Security checks failed"
-          exit 1
-        fi
-        if [ "${{ needs.validate-config.result }}" != "success" ]; then
-          echo "Configuration validation failed"
           exit 1
         fi
         echo "All CI checks passed!"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OutMyLook
 
 ![CI](https://github.com/your-username/OutMyLook/workflows/CI/badge.svg)
-![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
+![Python](https://img.shields.io/badge/python-3.12+-blue.svg)
 ![Coverage](https://img.shields.io/badge/coverage-95%25-green.svg)
 
 A Python application for managing Microsoft Outlook emails using the Microsoft Graph API.
@@ -18,7 +18,7 @@ A Python application for managing Microsoft Outlook emails using the Microsoft G
 
 ## Prerequisites
 
-- Python 3.10 or higher
+- Python 3.12 or higher
 - pip (Python package installer)
 - Microsoft account (@outlook.com, @hotmail.com, @live.com, or organizational account)
 - Azure AD application registration (see [Setup Guide](docs/SETUP.md) for step-by-step Azure setup)
@@ -231,7 +231,7 @@ All checks run automatically via pre-commit hooks and CI.
 GitHub Actions runs the following checks on every push and PR:
 
 1. **Lint**: Black, isort, flake8, mypy
-2. **Test**: pytest across Python 3.10, 3.11, 3.12
+2. **Test**: pytest across Python 3.12
 3. **Coverage**: 95% minimum coverage
 4. **Security**: bandit and pip-audit
 

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -51,10 +51,7 @@ All CI checks must pass before merging:
 
 **Strict Status Checks:**
 - `Lint and Code Quality` - Code formatting, linting, and type checking
-- `Test Python 3.10` - Tests on Python 3.10
-- `Test Python 3.11` - Tests on Python 3.11
 - `Test Python 3.12` - Tests on Python 3.12
-- `Validate Configuration` - Configuration file validation
 - `CI Status Check` - Final CI status verification
 
 **Non-blocking Checks:**
@@ -121,10 +118,7 @@ The configuration file is located at `scripts/github/branch-protection-config.js
   - [x] Require branches to be up to date before merging
   - Add these status checks:
     - `Lint and Code Quality`
-    - `Test Python 3.10`
-    - `Test Python 3.11`
     - `Test Python 3.12`
-    - `Validate Configuration`
     - `CI Status Check`
 - [x] Require conversation resolution before merging
 - [x] Require linear history

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -24,7 +24,7 @@ The CI pipeline runs on every push to `main` and `develop` branches, and on all 
 
 **Purpose**: Run unit tests across Python versions
 
-**Matrix**: Python 3.10, 3.11, 3.12
+**Matrix**: Python 3.12
 
 **Tools**:
 - **pytest**: Test framework

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -14,7 +14,7 @@ You should see `(venv)` prefix in your terminal when it's active.
 
 ## Prerequisites
 
-- Python 3.10 or higher
+- Python 3.12 or higher
 - pip (Python package installer)
 - git
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 127
-target-version = ['py310', 'py311', 'py312']
+target-version = ['py312']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -32,7 +32,7 @@ addopts = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 warn_unused_ignores = true

--- a/scripts/github/branch-protection-config.json
+++ b/scripts/github/branch-protection-config.json
@@ -3,10 +3,7 @@
     "strict": true,
     "contexts": [
       "Lint and Code Quality",
-      "Test Python 3.10",
-      "Test Python 3.11",
       "Test Python 3.12",
-      "Validate Configuration",
       "CI Status Check"
     ]
   },


### PR DESCRIPTION
Per amendez13/automation#395. ~7 jobs → 4; coverage gate moved into test, validate folded into lint; docs + branch-protection-config.json updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)